### PR TITLE
会員マイページ機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,5 @@ gem 'devise'
 
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'jquery-rails'
+
+gem 'paranoia'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    paranoia (2.4.2)
+      activerecord (>= 4.0, < 6.1)
     public_suffix (4.0.5)
     puma (3.12.6)
     rack (2.2.3)
@@ -222,6 +224,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  paranoia
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.3)
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/customers/customers.coffee
+++ b/app/assets/javascripts/customers/customers.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/customers/customers.scss
+++ b/app/assets/stylesheets/customers/customers.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the customers::customers controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/customers/customers_controller.rb
+++ b/app/controllers/customers/customers_controller.rb
@@ -1,0 +1,31 @@
+class Customers::CustomersController < ApplicationController
+
+	def show
+		@customer = current_customer
+	end
+
+	def edit
+		@customer = current_customer
+	end
+
+	def update
+		@customer = current_customer
+		@customer.update(customer_params)
+		redirect_to customers_profile_path, notice: "編集が完了しました。"
+	end
+
+	def confirm
+	end
+
+	def destroy
+		current_customer.destroy
+		sign_out_and_redirect(current_customer)
+	end
+
+
+
+	private
+def customer_params
+  params.require(:customer).permit(:surname, :first_name, :surname_kana, :first_name_kana, :postal_code, :address, :phone_number)
+end
+end

--- a/app/controllers/customers/registrations_controller.rb
+++ b/app/controllers/customers/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Customers::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up

--- a/app/helpers/customers/customers_helper.rb
+++ b/app/helpers/customers/customers_helper.rb
@@ -1,0 +1,2 @@
+module Customers::CustomersHelper
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,6 +1,9 @@
 class Customer < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+  acts_as_paranoid
+  
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 end

--- a/app/views/customers/customers/confirm.html.erb
+++ b/app/views/customers/customers/confirm.html.erb
@@ -1,0 +1,17 @@
+<div class="col-xs-6 col-xs-offset-3">
+
+	<div class="text-center">
+
+		<h3>本当に退会しますか？</h3>
+		<p>退会すると、会員登録情報や<br>
+			これまでの購入履歴が閲覧できなくなります。<br>
+			退会する場合は、「退会する」をクリックしてください。<br></p>
+
+		<div class="actions text-center">
+    		<%= link_to "退会しない",customers_profile_path, class:"btn btn-primary" %>
+    		<%= link_to "退会する", customers_delete_path, method: :patch, class:"btn btn-danger", data: { confirm: 'Are you sure?' } %>
+  		</div>
+
+	</div>
+
+</div>

--- a/app/views/customers/customers/edit.html.erb
+++ b/app/views/customers/customers/edit.html.erb
@@ -1,0 +1,67 @@
+<div class="col-xs-6 col-xs-offset-3">
+
+  <h3 >登録情報編集</h3>
+
+  <%= form_for(@customer, url:"/customers/profile") do |f| %>
+
+  <div class="field form-group">
+    <%= f.label :名前, class: "col-sm-4" %>
+    <div class="col-sm-4">
+      <%= f.label :姓%>
+      <%= f.text_field :surname, autofocus: true, autocomplete: "surname" %>
+    </div>
+    <div class="col-sm-4">
+      <%= f.label :名%>
+      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name" %>
+    </div>
+  </div>
+
+  <div class="field form-group">
+    <%= f.label :フリガナ, class: "col-sm-4" %>
+    <div class="col-sm-4">
+    <%= f.label :姓 %>
+    <%= f.text_field :surname_kana, autofocus: true, autocomplete: "surname_kana" %>
+  </div>
+
+  <div class="col-sm-4">
+    <%= f.label :名 %>
+    <%= f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana" %>
+  </div>
+  </div>
+
+  <div class="field form-group">
+    <%= f.label :メールアドレス, class: "col-sm-6" %>
+    <div class="col-sm-4">
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+  </div>
+
+  <div class="field form-group">
+    <%= f.label :郵便番号（ハイフンなし）, class: "col-sm-6" %>
+    <div class="col-sm-4">
+    <%= f.text_field :postal_code, autofocus: true, autocomplete: "postal_code" %>
+  </div>
+  </div>
+
+  <div class="field form-group">
+    <%= f.label :住所, class: "col-sm-6" %>
+    <div class="col-sm-4">
+    <%= f.text_field :address, autofocus: true, autocomplete: "address" %>
+  </div>
+  </div>
+
+  <div class="field form-group">
+    <%= f.label :電話番号（ハイフンなし）, class: "col-sm-6" %>
+    <div class="col-sm-4">
+    <%= f.text_field :phone_number, autofocus: true, autocomplete: "phone_number" %>
+  </div>
+  </div>
+
+  <div class="actions text-center">
+    <%= f.submit "編集内容を保存する", class: "btn btn-primary" %>
+    <%= link_to "退会する", customers_delete_confirm_path, class: "btn btn-danger" %>
+  </div>
+
+<% end %>
+
+</div>

--- a/app/views/customers/customers/show.html.erb
+++ b/app/views/customers/customers/show.html.erb
@@ -1,0 +1,54 @@
+<div class="col-xs-6 col-xs-offset-3">
+<p id="notice"><%= notice %></p><br>
+
+<h3>マイページ</h3>
+
+<table>
+<th >登録情報</th>
+<td><%= link_to "編集する", customers_profile_edit_path, class: "btn btn-primary" %></td>
+<td><button type="button" class="btn btn-primary">パスワードを変更する</button></td>
+</table>
+
+<table class="table table-bordered">
+	<tbody>
+		<tr>
+			<td class="active">氏名</td>
+			<td><%= @customer.surname %><%= @customer.first_name %></td>
+		</tr>
+		<tr>
+			<td class="active">カナ</td>
+			<td><%= @customer.surname_kana %><%= @customer.first_name_kana %></td>
+		</tr>
+		<tr>
+			<td class="active">郵便番号</td>
+			<td><%= @customer.postal_code %></td>
+		</tr>
+		<tr>
+			<td class="active">住所</td>
+			<td><%= @customer.address %></td>
+		</tr>
+		<tr>
+			<td class="active">電話番号</td>
+			<td><%= @customer.phone_number %></td>
+		</tr>
+		<tr>
+			<td class="active">メールアドレス</td>
+			<td><%= @customer.email %></td>
+		</tr>
+	</tbody>
+　</table>
+
+<div class="col-xs-7">
+<table class="col-xs-6">
+<th>配送先</th>
+<td><button type="button" class="btn btn-primary">一覧を見る</button></td>
+</table>
+
+<table class="col-xs-6">
+<th>注文履歴</th>
+<td><button type="button" class="btn btn-primary">一覧を見る</button></td>
+</table>
+</div>
+
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,15 @@ Rails.application.routes.draw do
   	registrations: 'customers/registrations'
   }
 
+  namespace :customers do
+  	get '/profile' => 'customers#show'
+  	get '/profile/edit' => 'customers#edit'
+    put '/profile' => 'customers#update'
+    patch '/profile' => 'customers#update'
+    get '/delete/confirm' => 'customers#confirm'
+    patch '/delete' => 'customers#destroy'
+  end
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'homes#top'
   get '/about' => 'homes#about'

--- a/db/migrate/20200702045648_add_column_to_customers.rb
+++ b/db/migrate/20200702045648_add_column_to_customers.rb
@@ -7,6 +7,6 @@ class AddColumnToCustomers < ActiveRecord::Migration[5.2]
   	add_column :customers, :postal_code, :string
   	add_column :customers, :address, :text
   	add_column :customers, :phone_number, :string
-  	add_column :customers, :withdrawal_status, :boolean
+  	add_column :customers, :withdrawal_status, :boolean, default: false, null: false
   end
 end

--- a/db/migrate/20200704102850_rewmove_withdrawal_status_from_customers.rb
+++ b/db/migrate/20200704102850_rewmove_withdrawal_status_from_customers.rb
@@ -1,0 +1,5 @@
+class RewmoveWithdrawalStatusFromCustomers < ActiveRecord::Migration[5.2]
+  def change
+  	remove_column :customers, :withdrawal_status, :boolean
+  end
+end

--- a/db/migrate/20200704103906_add_deleted_at_to_customers.rb
+++ b/db/migrate/20200704103906_add_deleted_at_to_customers.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToCustomers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :customers, :deleted_at, :datetime
+    add_index :customers, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_02_045648) do
+ActiveRecord::Schema.define(version: 2020_07_04_103906) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -39,7 +39,8 @@ ActiveRecord::Schema.define(version: 2020_07_02_045648) do
     t.string "postal_code"
     t.text "address"
     t.string "phone_number"
-    t.boolean "withdrawal_status"
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end

--- a/test/controllers/customers/customers_controller_test.rb
+++ b/test/controllers/customers/customers_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Customers::CustomersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
* 登録情報の閲覧・編集・サイトの退会ができます。
* 配送先一覧、注文履歴は空ボタンです。

## 仕様書からの変更点など
* gem paranoiaを導入
* paranoia使用のためwithdrawal_statusカラムを削除、deleated_atを追加
* /customers/editがすでにdeviseにて使用されていたため、/customers/profile/editに変更しています。

## 要確認
* 前回作成したログイン機能がうまく働いていなかったので修正しています。（slackにて共有した件）
* 退会時のアラートをとりあえずつけたけど必要か不明、必要なら日本語化が必要（テスト仕様書に「アラートが表示される」とあるが、確認画面のことなのかポップアップメッセージのことなのかがわからず。。。）
* 論理削除のため、退会後に同じメールアドレスを使用しての新規登録が不可になってます。要件にはなかったからこのままでいいかな？


