### PR TITLE
配送先登録追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+	protect_from_forgery with: :null_session
 end

--- a/app/controllers/customers/orders_controller.rb
+++ b/app/controllers/customers/orders_controller.rb
@@ -4,24 +4,51 @@ class Customers::OrdersController < ApplicationController
 		@order = Order.new
 		@customer = current_customer
 	end
+
 	def create
 		@order = Order.new(order_params)
 		order.customer_id = customer.id
 		@order.save
 		redirect_to customers_orders
 	end
-    def confirm
-    	@order = Order.new(order_params)
-    	if @order.payment_informantion == 0 then
-    	 @value = "クレジットカード"
-    	elsif @order.payment_informantion == 1 then
-         @value = "銀行振込"
-    	end
+
+  def confirm
+  	@order = Order.new(order_params)
+  	if @order.payment_informantion == 0 then
+  	 @value = "クレジットカード"
+  	elsif @order.payment_informantion == 1 then
+       @value = "銀行振込"
+  	end
+
+    if params[:address_number] == "0" then
+     @order.ship_postal_code = current_customer.postal_code
+     @order.ship_address = current_customer.address
+     @order.ship_name = current_customer.surname + current_customer.first_name
+
+    elsif params[:address_number] == "1" then
+      registered_address = ShippingAddress.find(params[:order][:shipping_addresses_id])
+      @order.ship_postal_code = registered_address.postal_code
+      @order.ship_address = registered_address.address
+      @order.ship_name = registered_address.name
+
+    elsif params[:address_number] == "2" then
+      
     end
+  end
 
  private
   def order_params
-    params.require(:order).permit(:address_number, :customer_id, :ship_address, :ship_name, :bill, :carriage, :payment_informantion, :order_status)
+    params.require(:order).permit(
+      :ship_postal_code,
+      :address_number,
+      :customer_id,
+      :ship_address,
+      :ship_name,
+      :bill,
+      :carriage,
+      :payment_informantion,
+      :order_status,
+    )
   end
 
 end

--- a/app/views/customers/cart_items/index.html.erb
+++ b/app/views/customers/cart_items/index.html.erb
@@ -63,7 +63,7 @@
   <div class="row">
     <div class="col-xs-4"></div>
     <div class="col-xs-4">
-      <%= link_to "情報入力に進む", root_path, class: "btn btn-success btn-lg" %>
+      <%= link_to "情報入力に進む", new_customers_order_path, class: "btn btn-success btn-lg" %>
     </div>
     <div class="col-xs-4"></div>
   </div>

--- a/app/views/customers/customers/show.html.erb
+++ b/app/views/customers/customers/show.html.erb
@@ -41,7 +41,7 @@
 <div class="col-xs-7">
 <table class="col-xs-6">
 <th>配送先</th>
-<td><button type="button" class="btn btn-primary">一覧を見る</button></td>
+<td><%= link_to "一覧を見る", customers_shipping_addresses_path, class: "btn btn-primary" %></td>
 </table>
 
 <table class="col-xs-6">

--- a/app/views/customers/orders/confirm.html.erb
+++ b/app/views/customers/orders/confirm.html.erb
@@ -13,24 +13,6 @@
 		</tr>
 	</thead>
 	<tbody>
-		<%# ship_address.each do |ship_address| %>
-		<tr>
-			<td>
-				<%# ship_address.postal_code %>
-			</td>
-			<td>
-				<%# ship_address.postal_code %>
-			</td>
-			<td>
-				<%# ship_address.postal_code %>
-			</td>
-			<td>
-				<%# ship_address.postal_code %>
-			</td>
-			<td>
-			</td>
-		</tr>
-		<%# end %>
 	</tbody>
 </table>
 
@@ -38,4 +20,6 @@
 <%= @value %>
 
 <h3>お届け先</h3>
-<%= @address %>
+<%= @order.ship_postal_code %>
+<%= @order.ship_address %>
+<%= @order.ship_name %>

--- a/app/views/customers/orders/new.html.erb
+++ b/app/views/customers/orders/new.html.erb
@@ -2,37 +2,36 @@
 <div class="container">
     <div class="row">
 		<h3>注文情報入力</h3>
-		  <%= form_for(@order, url: "/customers/orders/confirm", html: {method:'GET'}) do |f| %>
-		<h4>支払方法</h4>
-		  <label><%= f.radio_button :payment_informantion, "0" %>クレジットカード</label><br>
-		  <label><%= f.radio_button :payment_informantion, "1" %>銀行振込</label><br>
-		<h4>お届け先</h4>
-		  <label><%= radio_button_tag :address_number, "0" %>ご自身の住所</label><br>
-		  <%= @customer.postal_code + @customer.address %><br>
-		  <%= @customer.surname + @customer.first_name %><br>
-		  <label><%= radio_button_tag :address_number, "1" %>登録住所から選択</label><br>
-		  <%= f.collection_select :ship_address, ShippingAddress.all, :id, :full_address, include_blank: "--選択して下さい--" %><br>
+		<%= form_with(model: @order, url: "/customers/orders/confirm", method: "GET", local: true ) do |f| %>
+			<h4>支払方法</h4>
+			<label><%= f.radio_button :payment_informantion, "0" %>クレジットカード</label><br>
+			<label><%= f.radio_button :payment_informantion, "1" %>銀行振込</label><br>
+			<h4>お届け先</h4>
+			<label><%= radio_button_tag :address_number, "0" %>ご自身の住所</label><br>
+			<%= @customer.postal_code + @customer.address %><br>
+			<%= @customer.surname + @customer.first_name %><br>
+			<label><%= radio_button_tag :address_number, "1" %>登録住所から選択</label><br>
+			<%= f.collection_select :shipping_addresses_id, current_customer.shipping_addresses, :id, :full_address, include_blank: "--選択して下さい--" %><br>
+			<label><%= radio_button_tag :address_number, "2" %>新しいお届け先</label><br>
 
-		  <label><%= radio_button_tag :address_number, "2" %>新しいお届け先</label><br>
+			<div class="field form-group">
+				<%= f.label :郵便番号ハイフンなし %>
+				<%= f.text_field :ship_postal_code %>
+			</div>
 
-	    <div class="field form-group">
-			<%= f.label :郵便番号ハイフンなし %>
-			<%= f.text_field :ship_postal_code %>
-		</div>
+			<div class="field form-group">
+				<%= f.label :住所 %>
+				<%= f.text_field :ship_address %>
+			</div>
 
-	    <div class="field form-group">
-			<%= f.label :住所 %>
-			<%= f.text_field :ship_address %>
-		</div>
+			<div class="field form-group">
+				<%= f.label :宛名 %>
+				<%= f.text_field :ship_name %>
+			</div>
 
-	    <div class="field form-group">
-			<%= f.label :宛名 %>
-			<%= f.text_field :ship_name %>
-		</div>
-
-		<div class="actions row">
-			<%= f.submit class: "btn btn-primary col-xs-3" %>
-		</div>
-      <% end %>
+			<div class="actions row">
+				<%= f.submit class: "btn btn-primary col-xs-3" %>
+			</div>
+		<% end %>
     </div>
 </div>


### PR DESCRIPTION
## 概要
* 注文情報入力〜注文情報確認画面までの遷移
* お届け先の選択ができるようになりました。

## 変更点
* f.collection_selectにて、カラム以外の名前を指定したいため、form_forからform_withに変更
* コントローラーにて、選択した住所をorderテーブルのカラム（ship_postal_code,ship_address,ship_name）にそれぞれ入れています。新規入力されたものは直接入力しています。

## その他
* 確認画面で商品を表示する部分は一切触れていません。
